### PR TITLE
comments notification for expertise

### DIFF
--- a/application/workprogramsapp/admin.py
+++ b/application/workprogramsapp/admin.py
@@ -16,7 +16,7 @@ from .models import (
 # FieldOfStudyWorkProgram,
 from .models import EducationalProgram, GeneralCharacteristics, Department, Profession, SkillsOfProfession, SkillsOfRole, \
     Role, ProfessionalAreaOfGeneralCharacteristics, ProfessionalStandard
-from .notifications.models import ExpertiseNotification, UserNotification
+from .notifications.models import ExpertiseNotification, UserNotification, NotificationComments
 
 from .workprogram_additions.models import AdditionalMaterial, StructuralUnit, UserStructuralUnit
 
@@ -105,3 +105,4 @@ admin.site.register(CourseCredit)
 admin.site.register(CourseFieldOfStudy)
 admin.site.register(ElectiveWorkProgramInWorkProgramChangeInDisciplineBlockModule)
 admin.site.register(WorkProgramIdStrUpForIsu)
+admin.site.register(NotificationComments)

--- a/application/workprogramsapp/expertise/models.py
+++ b/application/workprogramsapp/expertise/models.py
@@ -74,6 +74,6 @@ class ExpertiseComments(models.Model):
     ]
 
     comment_block = models.CharField(choices=BLOCK_CHOICES, max_length=1024, verbose_name="Блок комментария")
-    user_expertise = models.ForeignKey('UserExpertise', on_delete=models.CASCADE)
+    user_expertise = models.ForeignKey('UserExpertise', on_delete=models.CASCADE, related_name="user_expertise_comment")
     comment_text = models.CharField(max_length=50000, verbose_name="Комментарий")
     comment_date = models.DateTimeField(auto_now_add=True, blank=True, verbose_name='Дата комментария')

--- a/application/workprogramsapp/expertise/serializers.py
+++ b/application/workprogramsapp/expertise/serializers.py
@@ -139,3 +139,17 @@ class WorkProgramShortForExperiseSerializerWithStructUnitWithEditors(serializers
         model = WorkProgram
         fields = ['id', 'title', 'discipline_code', 'qualification', 'prerequisites', 'outcomes', 'structural_unit',
                   'editors']
+
+
+class CommentSerializerFull(serializers.ModelSerializer):
+    """
+    Сериализатор для notifications\serializers.py  ExpertiseCommentsNotificationSerializer
+    """
+
+    def to_representation(self, value):
+        self.fields['user_expertise'] = UserExpertiseForExpertiseSerializer(many=False, read_only=True)
+        return super().to_representation(value)
+
+    class Meta:
+        model = ExpertiseComments
+        fields = "__all__"

--- a/application/workprogramsapp/expertise/serializers.py
+++ b/application/workprogramsapp/expertise/serializers.py
@@ -141,13 +141,25 @@ class WorkProgramShortForExperiseSerializerWithStructUnitWithEditors(serializers
                   'editors']
 
 
+class ShortExpertiseSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Expertise
+        fields = "__all__"
+
+
 class CommentSerializerFull(serializers.ModelSerializer):
     """
     Сериализатор для notifications\serializers.py  ExpertiseCommentsNotificationSerializer
     """
+    expertise = serializers.SerializerMethodField()
+
+    def get_expertise(self, instance):
+        return ShortExpertiseSerializer(
+            instance=Expertise.objects.get(expertse_users_in_rpd__user_expertise_comment=instance)).data
 
     def to_representation(self, value):
         self.fields['user_expertise'] = UserExpertiseForExpertiseSerializer(many=False, read_only=True)
+
         return super().to_representation(value)
 
     class Meta:

--- a/application/workprogramsapp/notifications/models.py
+++ b/application/workprogramsapp/notifications/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from workprogramsapp.expertise.models import Expertise
+from workprogramsapp.expertise.models import Expertise, ExpertiseComments
 from workprogramsapp.models import Topic, WorkProgram
 from django.conf import settings
 
@@ -17,7 +17,7 @@ class UserNotification(models.Model):
                               default='unread')
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, blank=True, null=True)
     message = models.CharField(max_length=4096, verbose_name="Сообщение нотификации", blank=True, null=True)
-    notification_date=models.DateTimeField(auto_now_add=True, blank=True, null=True )
+    notification_date = models.DateTimeField(auto_now_add=True, blank=True, null=True)
 
     class Meta:
         ordering = ('-notification_date',)
@@ -28,3 +28,9 @@ class ExpertiseNotification(UserNotification):
     Нотификации об экспертизе
     """
     expertise = models.ForeignKey(Expertise, on_delete=models.CASCADE, blank=True, null=True)
+
+
+
+
+class NotificationComments(UserNotification):
+    comment_new = models.ForeignKey(ExpertiseComments, on_delete=models.CASCADE, blank=True, null=True)

--- a/application/workprogramsapp/notifications/models.py
+++ b/application/workprogramsapp/notifications/models.py
@@ -34,3 +34,4 @@ class ExpertiseNotification(UserNotification):
 
 class NotificationComments(UserNotification):
     comment_new = models.ForeignKey(ExpertiseComments, on_delete=models.CASCADE, blank=True, null=True)
+

--- a/application/workprogramsapp/notifications/serializers.py
+++ b/application/workprogramsapp/notifications/serializers.py
@@ -3,7 +3,8 @@ from rest_framework import serializers
 
 from dataprocessing.models import User
 from workprogramsapp.expertise.common_serializers import ShortExpertiseSerializer
-from workprogramsapp.notifications.models import UserNotification, ExpertiseNotification
+from workprogramsapp.expertise.serializers import CommentSerializer, CommentSerializerFull
+from workprogramsapp.notifications.models import UserNotification, ExpertiseNotification, NotificationComments
 
 
 # Модели данных
@@ -12,6 +13,7 @@ from workprogramsapp.notifications.models import UserNotification, ExpertiseNoti
 
 class NotificationSerializer(serializers.ModelSerializer):
     expertise = serializers.SerializerMethodField()
+    expertise_comment = serializers.SerializerMethodField()
     basic = serializers.SerializerMethodField()
 
     def get_expertise(self, instance):
@@ -22,15 +24,21 @@ class NotificationSerializer(serializers.ModelSerializer):
         except ExpertiseNotification.DoesNotExist:
             return None
 
+    def get_expertise_comment(self, instance):
+        try:
+            exp = ExpertiseCommentsNotificationSerializer(
+                instance=NotificationComments.objects.get(usernotification_ptr_id=instance.id)).data
+            return exp
+        except NotificationComments.DoesNotExist:
+            return None
 
     def get_basic(self, instance):
         return NotificationCreateSerializer(
             instance=UserNotification.objects.get(id=instance.id)).data
 
-
     class Meta:
         model = UserNotification
-        fields = ["expertise", "basic"]
+        fields = ["expertise_comment", "expertise", "basic"]
 
 
 class ExpertiseNotificationSerializer(serializers.ModelSerializer):
@@ -38,6 +46,14 @@ class ExpertiseNotificationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ExpertiseNotification
+        fields = "__all__"
+
+
+class ExpertiseCommentsNotificationSerializer(serializers.ModelSerializer):
+    comment_new = CommentSerializerFull(many=False)
+
+    class Meta:
+        model = NotificationComments
         fields = "__all__"
 
 
@@ -49,7 +65,7 @@ class NotificationCreateSerializer(serializers.ModelSerializer):
             for user in users:
                 UserNotification.objects.create(user=user, message=validated_data["message"])
             return validated_data
-        notification= UserNotification.objects.create(**validated_data)
+        notification = UserNotification.objects.create(**validated_data)
         return notification
 
     class Meta:


### PR DESCRIPTION
в /api/notifications/list появилось новое поле: expertise_comment, если оно не null, значит уведомление пришло о комментарии к экспертизе (внутри json есть указание на рабочую программу и экспертизу чтобы перейти по ссылке)

Логика работы приходящих уведомлений:
1) Любой написанный комментарий не приходит уведомлением автору комментария
2) Уведомление о любом написанном комментарии приходит всем редакторам
3) Если эксперт написал комментарий в каком-то блоке РПД, и после его комментария в этом же блоке появился еще один - ему приходит уведомление
4) Если же редактор написал комментарий в каком-то блоке, в котором эксперт комментариев не писал, то уведомление придёт только редакторам, минуя эксперта
