### PR TITLE
Wait for workProgramId to dispatch

### DIFF
--- a/frontend/src/containers/WorkProgram/Competences/Competences.tsx
+++ b/frontend/src/containers/WorkProgram/Competences/Competences.tsx
@@ -38,9 +38,10 @@ export default React.memo(() => {
   }
 
   useEffect(() => {
-    dispatch(actions.getResults(workProgramId))
-    dispatch(actions.getResults(workProgramId))
-  }, [])
+    if (workProgramId) {
+      dispatch(actions.getResults(workProgramId))
+    }
+  }, [workProgramId]);
 
   const deleteCompetence = (competenceId: number) => {
     dispatch(actions.deleteZUN(competenceId))


### PR DESCRIPTION
Это, скорее, косметический дефект. Экшен `SET_WORK_PROGRAM` (добавление в стейт данных РПД, в том числе и айдишника) срабатывал сильно позже, чем `WORK_PROGRAM_GET_RESULTS`. Поэтому получение результатов в первый раз срабатывало вхолостую с пустым payload, а второй раз уже успешно. Добавила проверку на пустоту, чтобы избежать напрасных запросов.

@Poline не подскажешь, с какой целью в `useEffect` один и тот же экшен диспатчился два раза? Убрала второй вызов — никаких изменений в интерфейсе не заметила