### PR TITLE
competence in WP: fix ap and new endpoint

### DIFF
--- a/application/workprogramsapp/educational_program/serializers.py
+++ b/application/workprogramsapp/educational_program/serializers.py
@@ -7,12 +7,13 @@ from rest_framework.fields import BooleanField, SerializerMethodField
 # Другие сериализаторы
 from dataprocessing.serializers import userProfileSerializer
 from workprogramsapp.models import EducationalProgram, GeneralCharacteristics, Department, \
-    ProfessionalStandard
+    ProfessionalStandard, ImplementationAcademicPlan
 # Модели данных
 from workprogramsapp.models import GeneralizedLaborFunctions, KindsOfActivity, \
     EmployerRepresentative, WorkProgram, Competence, Zun, Indicator, WorkProgramInFieldOfStudy, ObjectsOfActivity
 from workprogramsapp.serializers import ImplementationAcademicPlanSerializer, IndicatorSerializer, \
-    WorkProgramInFieldOfStudySerializerForCb
+    WorkProgramInFieldOfStudySerializerForCb, AcademicPlanInImplementationSerializer, \
+    FieldOfStudyImplementationSerializer
 from .educational_standart.serializers import TasksForEducationalStandardSerializer, \
     EducationalStandardSingleObjectSerializer
 from .general_prof_competencies.models import GroupOfGeneralProfCompetencesInEducationalStandard
@@ -257,3 +258,14 @@ class DepartmentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Department
         fields = "__all__"
+
+
+class ImplementationAcademicPlanShortSerializer(serializers.ModelSerializer):
+    academic_plan = AcademicPlanInImplementationSerializer()
+    field_of_study = FieldOfStudyImplementationSerializer(many=True)
+
+    # academic_plan = AcademicPlanSerializer()
+
+    class Meta:
+        model = ImplementationAcademicPlan
+        fields = ['id', "title", "qualification", 'academic_plan', 'field_of_study', 'year']

--- a/application/workprogramsapp/educational_program/urls.py
+++ b/application/workprogramsapp/educational_program/urls.py
@@ -5,7 +5,8 @@ from rest_framework.routers import DefaultRouter
 from workprogramsapp.educational_program.views import EducationalProgramCreateAPIView, EducationalProgramListAPIView, \
     EducationalProgramDetailsView, EducationalProgramDestroyView, EducationalProgramUpdateView, UploadCompetences, \
     GeneralizedLaborFunctionsSet, KindsOfActivitySet, EmployerSet, GetCompetenceMatrix, ObjectsOfActivitySet, \
-    academ_plan_check, UploadProfStandards, new_ordinal_numbers_for_modules_in_ap, gh_check
+    academ_plan_check, UploadProfStandards, new_ordinal_numbers_for_modules_in_ap, gh_check, \
+    get_all_ap_with_competences_and_indicators
 from workprogramsapp.educational_program.views import GeneralCharacteristicsCreateAPIView, \
     GeneralCharacteristicsListAPIView, \
     GeneralCharacteristicsDetailsView, GeneralCharacteristicsDestroyView, GeneralCharacteristicsUpdateView, \
@@ -48,6 +49,7 @@ urlpatterns = [
 
     # --Компетенции
     path('api/competence/upload_comptence_from_csv', UploadCompetences),
+    path('api/competence/get_all_by_ap_to_wp/<int:wp_id>', get_all_ap_with_competences_and_indicators),
 
     # --Матрица компетенций
     path('api/general_characteristic/competence_matrix/<int:gen_pk>', GetCompetenceMatrix),

--- a/application/workprogramsapp/educational_program/urls.py
+++ b/application/workprogramsapp/educational_program/urls.py
@@ -6,7 +6,7 @@ from workprogramsapp.educational_program.views import EducationalProgramCreateAP
     EducationalProgramDetailsView, EducationalProgramDestroyView, EducationalProgramUpdateView, UploadCompetences, \
     GeneralizedLaborFunctionsSet, KindsOfActivitySet, EmployerSet, GetCompetenceMatrix, ObjectsOfActivitySet, \
     academ_plan_check, UploadProfStandards, new_ordinal_numbers_for_modules_in_ap, gh_check, \
-    get_all_ap_with_competences_and_indicators
+    get_all_ap_with_competences_and_indicators, get_all_competences_and_indicators_for_wp
 from workprogramsapp.educational_program.views import GeneralCharacteristicsCreateAPIView, \
     GeneralCharacteristicsListAPIView, \
     GeneralCharacteristicsDetailsView, GeneralCharacteristicsDestroyView, GeneralCharacteristicsUpdateView, \
@@ -49,7 +49,10 @@ urlpatterns = [
 
     # --Компетенции
     path('api/competence/upload_comptence_from_csv', UploadCompetences),
-    path('api/competence/get_all_by_ap_to_wp/<int:wp_id>', get_all_ap_with_competences_and_indicators),
+    path('api/competence/get_all_ap_with_competences_and_indicators_to_wp/<int:wp_id>',
+         get_all_ap_with_competences_and_indicators),
+    path('api/competence/get_all_competences_and_indicators_for_wp/<int:wp_id>',
+         get_all_competences_and_indicators_for_wp),
 
     # --Матрица компетенций
     path('api/general_characteristic/competence_matrix/<int:gen_pk>', GetCompetenceMatrix),

--- a/application/workprogramsapp/educational_program/views.py
+++ b/application/workprogramsapp/educational_program/views.py
@@ -18,11 +18,12 @@ import pandas as pd
 # Сериализаторы
 from rest_framework.viewsets import GenericViewSet
 
+from dataprocessing.models import Items
 from workprogramsapp.educational_program.serializers import EducationalCreateProgramSerializer, \
     EducationalProgramSerializer, \
     GeneralCharacteristicsSerializer, DepartmentSerializer, EducationalProgramUpdateSerializer, \
     GeneralLaborFunctionsSerializer, KindsOfActivitySerializerForEd, EmployerSerializer, \
-    WorkProgramCompetenceIndicatorSerializer, ObjectsOfActivitySerializer
+    WorkProgramCompetenceIndicatorSerializer, ObjectsOfActivitySerializer, ImplementationAcademicPlanShortSerializer
 from .competence_handler import competence_dict_generator
 from .general_prof_competencies.models import IndicatorInGeneralProfCompetenceInGeneralCharacteristic, \
     GeneralProfCompetencesInGroupOfGeneralCharacteristic, GroupOfGeneralProfCompetencesInEducationalStandard
@@ -44,7 +45,7 @@ from .process_modules_for_matrix import recursion_module_matrix
 
 from .serializers import ProfessionalStandardSerializer
 
-from workprogramsapp.serializers import ImplementationAcademicPlanSerializer
+from workprogramsapp.serializers import ImplementationAcademicPlanSerializer, IndicatorSerializer
 
 # --Работа с образовательной программой
 from workprogramsapp.models import EducationalProgram, GeneralCharacteristics, Department, Profession, WorkProgram, \
@@ -499,3 +500,60 @@ def gh_check(request, gh_id):
         return Response({'message': 'email sent', 'status': True}, status=200)
     else:
         return Response({'message': 'academic plan was sent', 'status': False}, status=400)
+
+@api_view(['GET'])
+@permission_classes((IsAuthenticated,))
+def get_all_ap_with_competences_and_indicators(request, wp_id):
+    ap_list_dict = []
+    competences = Competence.objects.filter(
+        indicator_in_competencse__zun__wp_in_fs__work_program__id=wp_id).distinct()
+    for competence in competences:
+        zuns = Zun.objects.filter(wp_in_fs__work_program__id=wp_id,
+                                  indicator_in_zun__competence__id=competence.id)
+        for zun in zuns:
+            try:
+                indicator = Indicator.objects.get(competence=competence.id,
+                                                  zun__id=zun.id)
+                indicator = IndicatorSerializer(indicator).data
+            except:
+                indicator = None
+
+            items_array = []
+            items = Items.objects.filter(item_in_outcomes__item_in_wp__id=zun.id,
+                                         item_in_outcomes__item_in_wp__wp_in_fs__work_program__id=wp_id,
+                                         item_in_outcomes__item_in_wp__indicator_in_zun__competence__id=competence.id)
+            for item in items:
+                items_array.append({"id": item.id, "name": item.name})
+            modules = DisciplineBlockModule.objects.filter(
+                change_blocks_of_work_programs_in_modules__zuns_for_cb__zun_in_wp__id=zun.id)
+            queryset = ImplementationAcademicPlan.get_all_imp_by_modules(modules=modules).distinct()
+            for ap in queryset:
+                dict_with_ap = None
+                for ap_dict in ap_list_dict:
+                    if ap.id == ap_dict["id"]:
+                        dict_with_ap = ap_dict
+                        break
+                if not dict_with_ap:
+                    dict_with_ap = dict(ImplementationAcademicPlanShortSerializer(ap, many=False).data)
+                    dict_with_ap["competences"] = [
+                        {"id": competence.id, "name": competence.name, "number": competence.number,
+                         "zuns": [{"id": zun.id, "knowledge": zun.knowledge, "skills": zun.skills,
+                                   "attainments": zun.attainments, "indicator": indicator,
+                                   "items": items_array}]}]
+                    ap_list_dict.append(dict_with_ap)
+                else:
+                    dict_with_competences = None
+                    for competence_dict in dict_with_ap["competences"]:
+                        if competence.id == competence_dict["id"]:
+                            dict_with_competences = competence_dict
+                    if not dict_with_competences:
+                        dict_with_ap["competences"].append(
+                            {"id": competence.id, "name": competence.name, "number": competence.number,
+                             "zuns": [{"id": zun.id, "knowledge": zun.knowledge, "skills": zun.skills,
+                                       "attainments": zun.attainments, "indicator": indicator,
+                                   "items": items_array}]})
+                    else:
+                        dict_with_competences["zuns"].append({"id": zun.id, "knowledge": zun.knowledge, "skills": zun.skills,
+                                       "attainments": zun.attainments, "indicator": indicator,
+                                   "items": items_array})
+    return Response(ap_list_dict, status=200)

--- a/application/workprogramsapp/models.py
+++ b/application/workprogramsapp/models.py
@@ -681,6 +681,17 @@ class ImplementationAcademicPlan(models.Model):
 
     def __str__(self):
         return 'НАШ ОП ид: ' + str(self.id) + ' / ' + 'ОП ИСУ ИД: ' + str(self.op_isu_id)
+    @staticmethod
+    def get_all_imp_by_modules(modules):
+        imp_list = ImplementationAcademicPlan.objects.none()
+        for module in modules:
+            if module.father_module.all():
+                imp_list = imp_list|ImplementationAcademicPlan.get_all_imp_by_modules(module.father_module.all())
+            else:
+                imp_list = imp_list | ImplementationAcademicPlan.objects.filter(
+                    academic_plan__discipline_blocks_in_academic_plan__modules_in_discipline_block=module)
+        return imp_list
+
 
 
 class DisciplineBlock(CloneMixin, models.Model):

--- a/application/workprogramsapp/signals.py
+++ b/application/workprogramsapp/signals.py
@@ -84,6 +84,12 @@ def expertise_notificator(sender, instance, created, **kwargs):
             ExpertiseNotification.objects.create(expertise=instance, user=user,
                                                  message=f'Экспертиза для {name_of_object} "{wp_exp.title}" поменяла свой статус на "{instance.get_expertise_status_display()}')
 
+    if instance.expertise_status == 'AC':
+        read_notifications_array = [False, False, False, False, False, False, False, False]
+        wp_exp.read_notifications = str(read_notifications_array).replace('[', '').replace(']', '')
+        wp_exp.save()
+
+
     # isu_client_credentials_request('https://dev.disc.itmo.su/api/v1/disciplines/:disc_id?status={status}&url=https://op.itmo.ru/work-program/{wp_id}'.format(status=instance.expertise_status, wp_id=wp_exp.id))
 
     isu_client_credentials_request(

--- a/application/workprogramsapp/views.py
+++ b/application/workprogramsapp/views.py
@@ -714,7 +714,7 @@ class WorkProgramDetailsView(generics.RetrieveAPIView):
         except:
 
             newdata.update({"rating": False})
-        competences = Competence.objects.filter(
+        """competences = Competence.objects.filter(
             indicator_in_competencse__zun__wp_in_fs__work_program__id=self.kwargs['pk']).distinct()
         competences_dict = []
         for competence in competences:
@@ -738,8 +738,8 @@ class WorkProgramDetailsView(generics.RetrieveAPIView):
                 for item in items:
                     items_array.append({"id": item.id, "name": item.name})
                 # serializer = WorkProgramInFieldOfStudySerializerForCb(WorkProgramInFieldOfStudy.objects.get(zun_in_wp = zun.id))
-                """queryset = ImplementationAcademicPlan.objects.filter(
-                    academic_plan__discipline_blocks_in_academic_plan__modules_in_discipline_block__change_blocks_of_work_programs_in_modules__zuns_for_cb__zun_in_wp__id=zun.id)"""
+                #queryset = ImplementationAcademicPlan.objects.filter(
+                #    academic_plan__discipline_blocks_in_academic_plan__modules_in_discipline_block__change_blocks_of_work_programs_in_modules__zuns_for_cb__zun_in_wp__id=zun.id)
                 modules = DisciplineBlockModule.objects.filter(
                     change_blocks_of_work_programs_in_modules__zuns_for_cb__zun_in_wp__id=zun.id)
                 queryset = ImplementationAcademicPlan.get_all_imp_by_modules(modules=modules)
@@ -752,7 +752,7 @@ class WorkProgramDetailsView(generics.RetrieveAPIView):
                                            WorkProgramInFieldOfStudy.objects.get(zun_in_wp=zun.id)).data["id"]})
             competences_dict.append({"id": competence.id, "name": competence.name, "number": competence.number,
                                      "zuns": zuns_array})
-        newdata.update({"competences": competences_dict})
+        newdata.update({"competences": competences_dict})"""
         newdata = OrderedDict(newdata)
         return Response(newdata, status=status.HTTP_200_OK)
 

--- a/application/workprogramsapp/views.py
+++ b/application/workprogramsapp/views.py
@@ -738,14 +738,18 @@ class WorkProgramDetailsView(generics.RetrieveAPIView):
                 for item in items:
                     items_array.append({"id": item.id, "name": item.name})
                 # serializer = WorkProgramInFieldOfStudySerializerForCb(WorkProgramInFieldOfStudy.objects.get(zun_in_wp = zun.id))
-                queryset = ImplementationAcademicPlan.objects.filter(
-                    academic_plan__discipline_blocks_in_academic_plan__modules_in_discipline_block__change_blocks_of_work_programs_in_modules__zuns_for_cb__zun_in_wp__id=zun.id)
+                """queryset = ImplementationAcademicPlan.objects.filter(
+                    academic_plan__discipline_blocks_in_academic_plan__modules_in_discipline_block__change_blocks_of_work_programs_in_modules__zuns_for_cb__zun_in_wp__id=zun.id)"""
+                modules = DisciplineBlockModule.objects.filter(
+                    change_blocks_of_work_programs_in_modules__zuns_for_cb__zun_in_wp__id=zun.id)
+                queryset = ImplementationAcademicPlan.get_all_imp_by_modules(modules=modules)
                 serializer = ImplementationAcademicPlanSerializer(queryset, many=True)
-                zuns_array.append({"id": zun.id, "knowledge": zun.knowledge, "skills": zun.skills,
-                                   "attainments": zun.attainments, "indicator": indicator,
-                                   "items": items_array, "educational_program": serializer.data,
-                                   "wp_in_fs": WorkProgramInFieldOfStudySerializerForCb(
-                                       WorkProgramInFieldOfStudy.objects.get(zun_in_wp=zun.id)).data["id"]})
+                if queryset.exists():
+                    zuns_array.append({"id": zun.id, "knowledge": zun.knowledge, "skills": zun.skills,
+                                       "attainments": zun.attainments, "indicator": indicator,
+                                       "items": items_array, "educational_program": serializer.data,
+                                       "wp_in_fs": WorkProgramInFieldOfStudySerializerForCb(
+                                           WorkProgramInFieldOfStudy.objects.get(zun_in_wp=zun.id)).data["id"]})
             competences_dict.append({"id": competence.id, "name": competence.name, "number": competence.number,
                                      "zuns": zuns_array})
         newdata.update({"competences": competences_dict})


### PR DESCRIPTION
1.  для отображения списка компетенций с привязанными к ним индикаторами и УП теперь сделан новый эндпоинт: api/competence/get_all_competences_and_indicators_for_wp/<int:wp_id>
2. Старое поле с компетенциями в эндпоинте для РПД закомментировано
3. Теперь в компетенциях отображаются только зуны привязанные к УП (модули без УП скрываются)
4. Починено отображение УП 2023+ года в УП
5. Сделан новый эндпоинт, позволяющий вывести список уп с компетенциями и ЗУНами для данной РПД: api/competence/get_all_by_ap_to_wp/<int:wp_id>
 --------------
6. Теперь комментарии к эспертизе автоматически прочитываются если она была переведена в статус "одобрено" 