### PR TITLE
competence filtering by ap and standard

### DIFF
--- a/application/workprogramsapp/educational_program/pk_comptencies/models.py
+++ b/application/workprogramsapp/educational_program/pk_comptencies/models.py
@@ -37,7 +37,7 @@ class PkCompetencesInGroupOfGeneralCharacteristic(models.Model):
                                     related_name="competence_in_group_of_pk_competences")
     # general_characteristic = models.ForeignKey('GeneralCharacteristics', on_delete=models.CASCADE, verbose_name="Общая характеристика", blank=True, null=True)
     competence = models.ForeignKey('Competence', on_delete=models.CASCADE, verbose_name="Компетенция", blank=True,
-                                   null=True)
+                                   null=True, related_name='pk_group')
     professional_standard = models.ForeignKey('ProfessionalStandard', on_delete=models.SET_NULL,
                                               verbose_name="Профессиональный стандарт", blank=True, null=True)
     generalized_labor_functions = models.ManyToManyField('GeneralizedLaborFunctions',

--- a/application/workprogramsapp/workprogram_additions/urls.py
+++ b/application/workprogramsapp/workprogram_additions/urls.py
@@ -3,7 +3,8 @@ from django.urls.conf import path
 from rest_framework.routers import DefaultRouter
 
 from .views import AdditionalMaterialSet, StructuralUnitSet, UserStructuralUnitSet, CompetencesSet, \
-    ChangeSemesterInEvaluationsCorrect, WorkProgramShortInfo, WorkProgramItemsPrerequisitesView
+    ChangeSemesterInEvaluationsCorrect, WorkProgramShortInfo, WorkProgramItemsPrerequisitesView, PracticeShortInfo, \
+    GIAShortInfo
 
 router = DefaultRouter()
 router.register(r'api/general_ch/additional_material_in_topic_of_rpd',
@@ -20,6 +21,8 @@ urlpatterns = [
 
     path('api/workprogram/make_evaluation_tools_correct', ChangeSemesterInEvaluationsCorrect),
     path('api/workprogram/isu/<int:isu_id>', WorkProgramShortInfo),
+    path('api/practice/isu/<int:isu_id>', PracticeShortInfo),
+    path('api/gia/isu/<int:isu_id>', GIAShortInfo),
     path('api/workprogram/items_isu/<int:isu_id>', WorkProgramItemsPrerequisitesView.as_view()),
 
 

--- a/application/workprogramsapp/workprogram_additions/views.py
+++ b/application/workprogramsapp/workprogram_additions/views.py
@@ -9,6 +9,8 @@ from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
 # Права доступа
+from gia_practice_app.GIA.models import GIA
+from gia_practice_app.Practice.models import Practice
 from workprogramsapp.permissions import IsRpdDeveloperOrReadOnly
 from .models import AdditionalMaterial, StructuralUnit, UserStructuralUnit
 # Сериализаторы
@@ -239,6 +241,50 @@ def WorkProgramShortInfo(request, isu_id):
         newdata.update({"wp_url": f"https://op.itmo.ru/work-program/{work_program.id}"})
         return Response(newdata)
     except WorkProgram.DoesNotExist:
+        raise Http404
+
+@api_view(['GET'])
+@permission_classes((IsAuthenticated,))
+def PracticeShortInfo(request, isu_id):
+    newdata = {}
+
+    try:
+        practice = Practice.objects.get(discipline_code=isu_id)
+        newdata.update(
+            {"title": practice.title})
+        try:
+            status = Expertise.objects.get(practice=practice).get_expertise_status_display()
+            if not status:
+                status = "В работе"
+            newdata.update(
+                {"expertise_status": status})
+        except Expertise.DoesNotExist:
+            newdata.update({"expertise_status": "В работе"})
+        newdata.update({"wp_url": f"https://op.itmo.ru/practice/{practice.id}"})
+        return Response(newdata)
+    except Practice.DoesNotExist:
+        raise Http404
+
+@api_view(['GET'])
+@permission_classes((IsAuthenticated,))
+def GIAShortInfo(request, isu_id):
+    newdata = {}
+
+    try:
+        gia = GIA.objects.get(discipline_code=isu_id)
+        newdata.update(
+            {"title": gia.title})
+        try:
+            status = Expertise.objects.get(gia=gia).get_expertise_status_display()
+            if not status:
+                status = "В работе"
+            newdata.update(
+                {"expertise_status": status})
+        except Expertise.DoesNotExist:
+            newdata.update({"expertise_status": "В работе"})
+        newdata.update({"wp_url": f"https://op.itmo.ru/gia/{gia.id}"})
+        return Response(newdata)
+    except Practice.DoesNotExist:
         raise Http404
 
 


### PR DESCRIPTION
Теперь в /api/competences можно указать два новых GET-параметра:
1. ap_id - [int] по id ImplementationAcademicPlan выводить все компетенции, входящие в ОХ для этого  УП
2. in_standard - [bool] выдает только компетенции входящие в образовательный стандрат + все ПК

-----------------
Теперь в список компетенций прокидывается информация об образовательном стандарте, если они в такой включены