### PR TITLE
copy zuns to another wp

### DIFF
--- a/application/workprogramsapp/educational_program/urls.py
+++ b/application/workprogramsapp/educational_program/urls.py
@@ -6,7 +6,8 @@ from workprogramsapp.educational_program.views import EducationalProgramCreateAP
     EducationalProgramDetailsView, EducationalProgramDestroyView, EducationalProgramUpdateView, UploadCompetences, \
     GeneralizedLaborFunctionsSet, KindsOfActivitySet, EmployerSet, GetCompetenceMatrix, ObjectsOfActivitySet, \
     academ_plan_check, UploadProfStandards, new_ordinal_numbers_for_modules_in_ap, gh_check, \
-    get_all_ap_with_competences_and_indicators, get_all_competences_and_indicators_for_wp, zun_many_remove
+    get_all_ap_with_competences_and_indicators, get_all_competences_and_indicators_for_wp, zun_many_remove, \
+    WorkProgramInFieldOfStudyWithAPByWP, zun_copy
 from workprogramsapp.educational_program.views import GeneralCharacteristicsCreateAPIView, \
     GeneralCharacteristicsListAPIView, \
     GeneralCharacteristicsDetailsView, GeneralCharacteristicsDestroyView, GeneralCharacteristicsUpdateView, \
@@ -54,6 +55,7 @@ urlpatterns = [
     path('api/competence/get_all_competences_and_indicators_for_wp/<int:wp_id>',
          get_all_competences_and_indicators_for_wp),
     path('api/competence/zun_many_remove', zun_many_remove),
+    path('api/competence/zun_many_copy', zun_copy),
 
     # --Матрица компетенций
     path('api/general_characteristic/competence_matrix/<int:gen_pk>', GetCompetenceMatrix),
@@ -62,6 +64,9 @@ urlpatterns = [
     path('api/competence/upload_prof_standard_from_csv', UploadProfStandards.as_view()),
 
     path('api/new_ordinal_numbers_for_modules_in_ap', new_ordinal_numbers_for_modules_in_ap),
+
+    # --Дополнительно
+    path('api/wp_in_fs/get_by_wp_id/<int:wp_id>', WorkProgramInFieldOfStudyWithAPByWP.as_view()),
 
     url(r'^', include(router.urls)),
     url(r'^', include('workprogramsapp.educational_program.key_competences.urls')),

--- a/application/workprogramsapp/educational_program/urls.py
+++ b/application/workprogramsapp/educational_program/urls.py
@@ -7,7 +7,7 @@ from workprogramsapp.educational_program.views import EducationalProgramCreateAP
     GeneralizedLaborFunctionsSet, KindsOfActivitySet, EmployerSet, GetCompetenceMatrix, ObjectsOfActivitySet, \
     academ_plan_check, UploadProfStandards, new_ordinal_numbers_for_modules_in_ap, gh_check, \
     get_all_ap_with_competences_and_indicators, get_all_competences_and_indicators_for_wp, zun_many_remove, \
-    WorkProgramInFieldOfStudyWithAPByWP, zun_copy
+    WorkProgramInFieldOfStudyWithAPByWP, zun_copy, zun_copy_by_wps
 from workprogramsapp.educational_program.views import GeneralCharacteristicsCreateAPIView, \
     GeneralCharacteristicsListAPIView, \
     GeneralCharacteristicsDetailsView, GeneralCharacteristicsDestroyView, GeneralCharacteristicsUpdateView, \
@@ -56,6 +56,7 @@ urlpatterns = [
          get_all_competences_and_indicators_for_wp),
     path('api/competence/zun_many_remove', zun_many_remove),
     path('api/competence/zun_many_copy', zun_copy),
+    path('api/competence/zun_copy_by_gh', zun_copy_by_wps),
 
     # --Матрица компетенций
     path('api/general_characteristic/competence_matrix/<int:gen_pk>', GetCompetenceMatrix),

--- a/application/workprogramsapp/isu_merge/academic_plan_update_2023/academic_plan_update_processor.py
+++ b/application/workprogramsapp/isu_merge/academic_plan_update_2023/academic_plan_update_processor.py
@@ -97,7 +97,7 @@ class AcademicPlanUpdateProcessor:
                 discipline_code=str(isu_academic_plan_discipline_json['id'])
             )
 
-        last_sem = 1
+
         # realisation_format = None
         # department = None
         """if wp_dict["format_id"] == 1:
@@ -168,7 +168,7 @@ class AcademicPlanUpdateProcessor:
             srs_hours[sem] = round(fake_srs - 0.1 * (srs_counter), 2)
             ze_v_sem[sem] = sem_dict["creditPoints"]
             contact_hours[sem] = round(srs_counter * 1.1, 2)
-            last_sem = len(cerf_list)
+            #last_sem = len(cerf_list)
 
         #work_program_object.description = isu_academic_plan_discipline_json["description"]
         work_program_object.language = isu_academic_plan_discipline_json["langCode"].lower()
@@ -180,7 +180,7 @@ class AcademicPlanUpdateProcessor:
         work_program_object.srs_hours_v2 = process_hours(srs_hours)
         work_program_object.ze_v_sem = process_hours(ze_v_sem)
         work_program_object.contact_hours_v2 = process_hours(contact_hours)
-        work_program_object.number_of_semesters = last_sem
+        work_program_object.number_of_semesters = isu_academic_plan_discipline_json["disciplineDuration"]
 
         work_program_object.save()
 

--- a/application/workprogramsapp/serializers.py
+++ b/application/workprogramsapp/serializers.py
@@ -1023,6 +1023,14 @@ class WorkProgramInFieldOfStudySerializer(serializers.ModelSerializer):
 #         model = Expertise
 #         fields = ['expertise_status']
 
+class WorkProgramInFieldOfStudyWithAPSerializer(serializers.ModelSerializer):
+    #work_program = WorkProgramShortForExperiseSerializer
+    work_program_change_in_discipline_block_module = WorkProgramChangeInDisciplineBlockModuleForWPinFSSerializer(
+        many=False)
+
+    class Meta:
+        model = WorkProgramInFieldOfStudy
+        fields = ['id', 'work_program_change_in_discipline_block_module']
 
 class WorkProgramSerializer(serializers.ModelSerializer):
     """Сериализатор рабочих программ"""


### PR DESCRIPTION
Код для копирования индикаторов из одной РПД в другую. Принцип работы:
1. Из текущей РПД выбираются объекты ЗУН по айди
2. С помощью нового эндпоинта `api/wp_in_fs/get_by_wp_id/<int:wp_id>` достаются айди объектов wp_in_fs привязанных к рпд куда надо скопировать индикаторы по айди <int:wp_id> . Эндпоинт возвращает информацию об УП со структурой как в эндпоинте РПД (в ручке для рабочей программы поле с такой структурой называется work_program_in_change_block)
3. в эндпоинт  `api/competence/zun_many_copy` указывается два списка: список айдюков-зунов для копирования и айдюков wp_in_fs для привязки к РПД 
4. Возвращается список объектов-зунов

  Пример:
```
    {
        "zuns_to_copy": [1, 2, 3],
        "wp_in_fss" : [1, 2, 3]
    }
```
