### PR TITLE
logging when expertise accepted

### DIFF
--- a/application/workprogramsapp/expertise/models.py
+++ b/application/workprogramsapp/expertise/models.py
@@ -42,9 +42,12 @@ class Expertise(models.Model):
         ('OFERTA', 'Оферта'),
     ]
 
-    work_program = models.ForeignKey('WorkProgram', related_name='expertise_with_rpd', on_delete=models.CASCADE, blank=True, null=True)
-    gia = models.ForeignKey('gia_practice_app.GIA', related_name='expertise_with_gia', on_delete=models.CASCADE, blank=True, null=True)
-    practice = models.ForeignKey('gia_practice_app.Practice', related_name='expertise_with_practice', on_delete=models.CASCADE,
+    work_program = models.ForeignKey('WorkProgram', related_name='expertise_with_rpd', on_delete=models.CASCADE,
+                                     blank=True, null=True)
+    gia = models.ForeignKey('gia_practice_app.GIA', related_name='expertise_with_gia', on_delete=models.CASCADE,
+                            blank=True, null=True)
+    practice = models.ForeignKey('gia_practice_app.Practice', related_name='expertise_with_practice',
+                                 on_delete=models.CASCADE,
                                  blank=True, null=True)
 
     expertise_type = models.CharField(choices=TYPE_CHOICES, max_length=1024, verbose_name="Тип экспертизы", blank=True,
@@ -96,3 +99,11 @@ class ExpertsOnStructuralUnit(models.Model):
     expert = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='experts_with_units', on_delete=models.CASCADE)
     structural_units = models.ManyToManyField('StructuralUnit', verbose_name='Эксперты',
                                               related_name='structural_units_with_experts')
+
+
+class ExpertiseChangeLog(models.Model):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="user_expertise_log",
+                             blank=True, null=True, )
+    expertise = models.ForeignKey('Expertise', on_delete=models.CASCADE, related_name="expertise_status_log",
+                                  blank=True, null=True, )
+    date_change = models.DateTimeField(blank=True, null=True, verbose_name='дата изменения')

--- a/application/workprogramsapp/expertise/serializers.py
+++ b/application/workprogramsapp/expertise/serializers.py
@@ -5,7 +5,7 @@ from dataprocessing.serializers import userProfileSerializer
 # from workprogramsapp.educational_program.serializers import EducationalProgramSerializer
 from gia_practice_app.GIA.models import GIA
 from gia_practice_app.Practice.models import Practice
-from workprogramsapp.expertise.models import UserExpertise, Expertise, ExpertiseComments
+from workprogramsapp.expertise.models import UserExpertise, Expertise, ExpertiseComments, ExpertiseChangeLog
 from workprogramsapp.models import WorkProgram
 from workprogramsapp.workprogram_additions.serializers import ShortStructuralUnitSerializer
 
@@ -228,4 +228,21 @@ class CommentSerializerFull(serializers.ModelSerializer):
 
     class Meta:
         model = ExpertiseComments
+        fields = "__all__"
+
+
+class ShortExpertiseSerializerWithWp(serializers.ModelSerializer):
+    work_program = WorkProgramShortForExperiseSerializerWithStructUnit(many=False)
+
+    class Meta:
+        model = Expertise
+        fields = ["id", "work_program"]
+
+
+class ExpertiseChangeLogSerializer(serializers.ModelSerializer):
+    expertise = ShortExpertiseSerializerWithWp(many=False)
+    user = userProfileSerializer(many=False)
+
+    class Meta:
+        model = ExpertiseChangeLog
         fields = "__all__"

--- a/application/workprogramsapp/expertise/urls.py
+++ b/application/workprogramsapp/expertise/urls.py
@@ -1,11 +1,14 @@
 from django.urls import path
 
-from workprogramsapp.expertise.views import UpdateCommentStatus, ExpertiseHistory, ChangeStatusesOfExpertiseWP
+from workprogramsapp.expertise.views import UpdateCommentStatus, ExpertiseHistory, ChangeStatusesOfExpertiseWP, \
+    ExpertiseChangeLogListView
 
 urlpatterns = [
 
     path('api/experise/comment/statusupdate', UpdateCommentStatus),
     path('api/expertise/history/<int:pk>', ExpertiseHistory, name="history_expertise"),
     path('api/experise/udate_statuses', ChangeStatusesOfExpertiseWP),
+    path('api/expertise/log_accept/<int:pk>', ExpertiseChangeLogListView.as_view(), name="expertise_log_pk"),
+    path('api/expertise/log_accept', ExpertiseChangeLogListView.as_view(), name="expertise_log"),
 
 ]

--- a/application/workprogramsapp/signals.py
+++ b/application/workprogramsapp/signals.py
@@ -93,9 +93,9 @@ def expertise_notificator(sender, instance, created, **kwargs):
 
     # isu_client_credentials_request('https://dev.disc.itmo.su/api/v1/disciplines/:disc_id?status={status}&url=https://op.itmo.ru/work-program/{wp_id}'.format(status=instance.expertise_status, wp_id=wp_exp.id))
 
-    """isu_client_credentials_request(
+    isu_client_credentials_request(
         'https://disc.itmo.su/api/v1/disciplines/{disc_id}?status={status}&url=https://op.itmo.ru/work-program/{wp_id}'.format(
-            disc_id=wp_exp.discipline_code, status=instance.get_expertise_status_display(), wp_id=wp_exp.id))"""
+            disc_id=wp_exp.discipline_code, status=instance.get_expertise_status_display(), wp_id=wp_exp.id))
 
 
 @receiver(post_save, sender=ExpertiseComments)

--- a/application/workprogramsapp/signals.py
+++ b/application/workprogramsapp/signals.py
@@ -93,9 +93,9 @@ def expertise_notificator(sender, instance, created, **kwargs):
 
     # isu_client_credentials_request('https://dev.disc.itmo.su/api/v1/disciplines/:disc_id?status={status}&url=https://op.itmo.ru/work-program/{wp_id}'.format(status=instance.expertise_status, wp_id=wp_exp.id))
 
-    isu_client_credentials_request(
+    """isu_client_credentials_request(
         'https://disc.itmo.su/api/v1/disciplines/{disc_id}?status={status}&url=https://op.itmo.ru/work-program/{wp_id}'.format(
-            disc_id=wp_exp.discipline_code, status=instance.get_expertise_status_display(), wp_id=wp_exp.id))
+            disc_id=wp_exp.discipline_code, status=instance.get_expertise_status_display(), wp_id=wp_exp.id))"""
 
 
 @receiver(post_save, sender=ExpertiseComments)


### PR DESCRIPTION
`api/expertise/log_accept/<int:pk>` - по id экспертизы выводит ЖСОН юзер + РПД с датами, когда у экспертизы была нажата кнопка "принять"
`api/expertise/log_accept?wp_id=id` - тоже самое но по id РПД
Возвращаемый ЖСОН описывается в сваггере