### PR TITLE
build(Pillow): обновлена зависимость Pillow

### DIFF
--- a/application/requirements.txt
+++ b/application/requirements.txt
@@ -65,7 +65,7 @@ packaging==21.3
 pandas==1.4.2
 pdf2docx==0.5.2
 pdfkit==0.6.1
-Pillow==7.0.0
+Pillow==8.3.1
 psycopg2==2.8.4
 pycparser==2.20
 PyJWT==1.7.1


### PR DESCRIPTION
Версия 7.0.0 библиотеки Pillow, указанная в requirements.txt не поддерживается в Python 3.9, хотя в проекте есть докерфайлы для сборки Python 3.9 образов. В коммите версия библиотеки была обновлена до 8.3.1, которая поддерживается как Python 3.9, так и Python 3.8


[Документация по установке Pillow](https://pillow.readthedocs.io/en/stable/installation.html)

<img width="683" alt="image" src="https://github.com/TonikX/analytics_backend/assets/17404773/003cc756-b15a-4544-bc78-0d3e067ed6c3">
